### PR TITLE
feat: update to match new format of sequencer request

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -28,7 +28,7 @@ const App = React.memo(function App() {
   const [identity, setIdentity] = React.useState<IdentityType>({
     id: "",
     verified: false,
-    inclusionProof: [],
+    inclusionProof: null,
     commitment: BigInt("0000"),
     trapdoor: BigInt("0000"),
     nullifier: BigInt("0000"),
@@ -45,7 +45,7 @@ const App = React.memo(function App() {
     }
 
     let verified = false;
-    let proof: IdentityType["inclusionProof"] = [];
+    let proof: IdentityType["inclusionProof"] = null;
     inclusionProof(encodeIdentityCommitment(storedIdentity.commitment))
       .then((result) => {
         verified = true;

--- a/src/App/Initial/Initial.tsx
+++ b/src/App/Initial/Initial.tsx
@@ -35,7 +35,7 @@ const Initial = React.memo(function Initial(props: {
 
       const id = encodedCommitment.slice(0, 10);
       let verified = false;
-      let proof: IdentityType["inclusionProof"] = [];
+      let proof: IdentityType["inclusionProof"] = null;
 
       try {
         proof = await inclusionProof(encodedCommitment);

--- a/src/lib/sequencer-service.ts
+++ b/src/lib/sequencer-service.ts
@@ -2,6 +2,11 @@ import { Environment } from "@/types";
 
 type EncodedCommitment = string; // this should be a 64-padded hex-string
 
+interface InclusionProofResponse {
+  root: EncodedCommitment;
+  proof: Record<"Left" | "Right", string>[];
+}
+
 const SEQUENCER_ENDPOINT: Record<Environment, string> = {
   [Environment.STAGING]: "https://signup.stage-crypto.worldcoin.dev/",
   [Environment.PRODUCTION]: "https://signup.crypto.worldcoin.dev/",
@@ -45,16 +50,9 @@ export async function inclusionProof(
   identityCommitment: EncodedCommitment,
   env: Environment = Environment.STAGING,
 ) {
-  return await postRequest<Record<"Left" | "Right", string>[]>(
+  return await postRequest<InclusionProofResponse>(
     "inclusionProof",
     identityCommitment,
     env,
   );
-}
-
-export async function getRoot(
-  identityCommitment: EncodedCommitment,
-  env: Environment = Environment.STAGING,
-) {
-  return await postRequest<string>("getRoot", identityCommitment, env);
 }

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -5,7 +5,7 @@ export interface Identity {
   readonly id: string;
   /** @default false */
   verified: boolean;
-  inclusionProof: Awaited<ReturnType<typeof inclusionProof>>;
+  inclusionProof: Awaited<ReturnType<typeof inclusionProof>> | null;
   /** identity commitment */
   readonly commitment: bigint;
   readonly trapdoor: bigint;


### PR DESCRIPTION
- Sequencer now sends both the root and the proof in the same `/inclusionProof` endpoint.
- @tino-otto ideally we would refetch this right before any proof is executed (in case the merkle root changed, because another user was added/removed). can we update? 