### PR TITLE
feat!: auth header

### DIFF
--- a/esbuild/config.js
+++ b/esbuild/config.js
@@ -1,9 +1,10 @@
-import "dotenv/config";
+import { transformFileAsync as babelTransformFileAsync } from "@babel/core";
 import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import autoprefixer from "autoprefixer";
 import browserslist from "browserslist";
 import cssnano from "cssnano";
+import "dotenv/config";
 import { resolveToEsbuildTarget } from "esbuild-plugin-browserslist";
 import { clean } from "esbuild-plugin-clean";
 import { copy } from "esbuild-plugin-copy";
@@ -13,7 +14,6 @@ import { fileURLToPath } from "node:url";
 import postcss from "postcss";
 import { optimize as optimizeSVG } from "svgo";
 import tailwindcss from "tailwindcss";
-import { transformFileAsync as babelTransformFileAsync } from "@babel/core";
 
 if (!process.env.INFURA_ID) {
   console.error(
@@ -158,5 +158,6 @@ export default /** @type {import('esbuild').BuildOptions} */ ({
   define: {
     global: "window",
     "process.env.INFURA_ID": `"${process.env.INFURA_ID}"`,
+    "process.env.SEQUENCER_PASSWORD": `"${process.env.SEQUENCER_PASSWORD}"`,
   },
 });

--- a/src/App/IdentityFaucet/IdentityFaucet.tsx
+++ b/src/App/IdentityFaucet/IdentityFaucet.tsx
@@ -29,11 +29,12 @@ const IdentityFaucet = React.memo(function IdentityFaucet() {
       setLoading(true);
 
       const result = await insertIdentity(input);
-      console.log("Identity insertion result:", result);
+      console.info("Identity successfully added.", result);
 
       setSubmitSuccess(true);
     } catch (err) {
       setSubmitSuccess(false);
+      console.error("Error inserting identity.", err);
     } finally {
       setLoading(false);
     }
@@ -109,7 +110,7 @@ const IdentityFaucet = React.memo(function IdentityFaucet() {
                 {submitSuccess === true &&
                   "Your identity was successfully added!"}
                 {submitSuccess === false &&
-                  "Looks like someting went wrong, please try again!"}
+                  "Looks like something went wrong, please check the console and try again."}
               </span>
 
               {submitSuccess !== null && (

--- a/src/lib/sequencer-service.ts
+++ b/src/lib/sequencer-service.ts
@@ -2,6 +2,8 @@ import { Environment } from "@/types";
 
 type EncodedCommitment = string; // this should be a 64-padded hex-string
 
+const SEQUENCER_PASSWORD = process.env.SEQUENCER_PASSWORD;
+
 interface InclusionProofResponse {
   root: EncodedCommitment;
   proof: Record<"Left" | "Right", string>[];
@@ -22,12 +24,19 @@ async function postRequest<T = unknown>(
   endpoint: string,
   identityCommitment: EncodedCommitment,
   env: Environment,
+  authenticateRequest?: boolean,
 ) {
+  if (authenticateRequest && !SEQUENCER_PASSWORD) {
+    throw "Sequencer password is not provided and this request requires authentication. Please set `SEQUENCER_PASSWORD` env var.";
+  }
   const res = await fetch(getUrl(endpoint, env).toString(), {
     method: "POST",
     body: JSON.stringify([1, identityCommitment]),
     headers: {
       "Content-Type": "application/json",
+      ...(authenticateRequest
+        ? { Authentication: `Basic ${btoa(`worldcoin:${SEQUENCER_PASSWORD}`)}` }
+        : {}),
     },
   });
   if (!res.ok)
@@ -43,7 +52,7 @@ export async function insertIdentity(
 ) {
   return await postRequest<{
     identityIndex: number;
-  }>("insertIdentity", identityCommitment, env);
+  }>("insertIdentity", identityCommitment, env, true);
 }
 
 export async function inclusionProof(

--- a/src/lib/sequencer-service.ts
+++ b/src/lib/sequencer-service.ts
@@ -35,7 +35,7 @@ async function postRequest<T = unknown>(
     headers: {
       "Content-Type": "application/json",
       ...(authenticateRequest
-        ? { Authentication: `Basic ${btoa(`worldcoin:${SEQUENCER_PASSWORD}`)}` }
+        ? { Authorization: `Basic ${btoa(`worldcoin:${SEQUENCER_PASSWORD}`)}` }
         : {}),
     },
   });


### PR DESCRIPTION
- Adds the relevant `Authorization` header to the sequencer's insert identity request.
- Identity submission to the faucet will now only work with the appropriate credentials. If you're developing on World ID, use the official faucet at https://mock-app.id.worldcoin.org/identity-faucet