### PR TITLE
chore: bump sidecar protocol crates

### DIFF
--- a/sidecar/Cargo.lock
+++ b/sidecar/Cargo.lock
@@ -6480,9 +6480,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e971b7c52f9a91a499ed15580da6dbfd593c6ad9c6d519c6b72c7f0c421355"
+checksum = "72389c80580ec74d8ab188c723f6b0253885867ffac41213a31e4554b4fd0658"
 dependencies = [
  "taceo-oprf-client",
  "taceo-oprf-core",
@@ -6491,9 +6491,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf-client"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b593b9ad62eac8e01229d1c764d2ea204241adfbd7ef6e292ec4027dc9421fc7"
+checksum = "e3991b17184d2be29e13ae22ef982f9ea3d1111d67236805cd7729116235461c"
 dependencies = [
  "ark-ec",
  "ciborium",
@@ -6515,9 +6515,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf-core"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d538b7fe97e0df8118f8b2a322f27d7e6585b4dfa1acc8da19196ade5696060"
+checksum = "c1409d82e88ad002d7946f6b5d37395a1d532133d9320b3284e27120ee1162db"
 dependencies = [
  "ark-ec",
  "ark-ff 0.5.0",
@@ -6537,9 +6537,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf-types"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fcb204762878cb53c645ca08030c38c35146c2eec627d3b18aaac85bab707"
+checksum = "13304cda45c09c625f278b2f8e49de5f583e447a276804d41877bfcf5e89f68e"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -7883,9 +7883,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-authenticator"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d49101e3f7645df65066d62aafcddf5e58a713aea7ac0ba8d417f90eadefa7"
+checksum = "8fed5aa94fe924d855a2ca40aadaae517315a2a24666d83092174b3c71a29456"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7894,6 +7894,7 @@ dependencies = [
  "base64 0.22.1",
  "bhttp",
  "eyre",
+ "getrandom 0.3.4",
  "hex",
  "ohttp",
  "rand 0.8.5",
@@ -7918,9 +7919,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-core"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098dc829e61fee475eadcbf5dab9687ce4b85531985ab8fb7cc4bbb6956f23f3"
+checksum = "26f136a169a1e2decbbf741c208961446d2f3377a19c930634aebee39f0fb6d3"
 dependencies = [
  "taceo-eddsa-babyjubjub",
  "world-id-authenticator",
@@ -7931,9 +7932,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-primitives"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc964ae49594d98cfd854385a9a6ee4b87ea70ffaee172d95b432e80471669b"
+checksum = "e19522e167d925e0c920671b41bb96edc82e7508f2d2730177c38c6cce2aa2c6"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -7942,7 +7943,7 @@ dependencies = [
  "arrayvec",
  "embed-doc-image",
  "eyre",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "hex",
  "provekit-common",
  "rand 0.8.5",
@@ -7966,9 +7967,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-proof"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa564fc8a89175bd0eb03e9a98095427c46ca6bae1465108b6b4bd2b3bce0c60"
+checksum = "098bb682b011c10c6a954927325470078000f771646df3264a079aba4b3295f9"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -8000,9 +8001,9 @@ dependencies = [
 
 [[package]]
 name = "world-id-registries"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464f2a67429855df77a21584629f634d31b9424d44d5d112c7c4c78bb5cb717e"
+checksum = "078bb8742f799133b9e5ff3eb1f4b3b1c9905ce479921be4c53ccb83467c1092"
 dependencies = [
  "alloy",
  "anyhow",

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -4,15 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# Keep this aligned with the world-id-core release used by walletkit-core 0.16.0.
-world-id-core = { version = "0.10.1", default-features = false, features = [
+# Keep this aligned with the world-id-core release used by walletkit.
+world-id-core = { version = "0.11.0", default-features = false, features = [
     "authenticator",
-    "embed-zkeys",
-    "zstd-compress-zkeys",
+    "compress-zkeys",
 ] }
 # Direct dep so we can pattern-match on `ProofError::RequestAuthError`. Pin
-# matches the version world-id-core 0.10.1 pulls in transitively.
-world-id-proof = { version = "0.10.1", default-features = false }
+# matches the version world-id-core 0.11.0 pulls in transitively.
+world-id-proof = { version = "0.11.0", default-features = false }
 
 axum = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }

--- a/sidecar/src/config.rs
+++ b/sidecar/src/config.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use serde_json::{Map, Value};
 use world_id_core::primitives::{Config, Credential};
 
 /// Top-level sidecar configuration loaded from JSON.
@@ -6,9 +7,57 @@ use world_id_core::primitives::{Config, Credential};
 pub struct SidecarConfig {
     /// Protocol configuration (chain_id, indexer_url, gateway_url, nullifier_oracle_urls, etc.)
     /// This is deserialized directly into the protocol's `Config` type.
+    #[serde(deserialize_with = "deserialize_protocol_config")]
     pub protocol: Config,
     /// Pre-configured identities with seeds and credentials.
     pub identities: Vec<IdentityConfig>,
+}
+
+fn deserialize_protocol_config<'de, D>(deserializer: D) -> Result<Config, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let mut value = Value::deserialize(deserializer)?;
+    if let Ok(config) = Config::deserialize(value.clone()) {
+        return Ok(config);
+    }
+
+    normalize_legacy_service_endpoint(&mut value, "indexer_url", "indexer")
+        .map_err(serde::de::Error::custom)?;
+    normalize_legacy_service_endpoint(&mut value, "gateway_url", "gateway")
+        .map_err(serde::de::Error::custom)?;
+
+    Config::deserialize(value).map_err(serde::de::Error::custom)
+}
+
+fn normalize_legacy_service_endpoint(
+    value: &mut Value,
+    legacy_key: &str,
+    endpoint_key: &str,
+) -> Result<(), String> {
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "protocol config must be a JSON object".to_string())?;
+
+    if object.contains_key(endpoint_key) {
+        return Ok(());
+    }
+
+    let url = object
+        .remove(legacy_key)
+        .ok_or_else(|| format!("missing field `{endpoint_key}`"))?;
+
+    let url = url
+        .as_str()
+        .ok_or_else(|| format!("field `{legacy_key}` must be a string"))?
+        .to_string();
+
+    let mut endpoint = Map::new();
+    endpoint.insert("type".to_string(), Value::String("direct".to_string()));
+    endpoint.insert("url".to_string(), Value::String(url));
+    object.insert(endpoint_key.to_string(), Value::Object(endpoint));
+
+    Ok(())
 }
 
 /// A single pre-configured identity.
@@ -18,6 +67,53 @@ pub struct IdentityConfig {
     pub seed: String,
     /// Pre-issued credentials for this identity.
     pub credentials: Vec<Credential>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SidecarConfig;
+
+    #[test]
+    fn loads_legacy_protocol_urls() {
+        let config: SidecarConfig = serde_json::from_str(
+            r#"{
+              "protocol": {
+                "chain_id": 480,
+                "registry_address": "0x8556d07D75025f286fe757C7EeEceC40D54FA16D",
+                "indexer_url": "https://indexer.example.com",
+                "gateway_url": "https://gateway.example.com",
+                "nullifier_oracle_urls": ["https://node0.example.com"],
+                "nullifier_oracle_threshold": 1
+              },
+              "identities": []
+            }"#,
+        )
+        .expect("legacy config should parse");
+
+        assert_eq!(config.protocol.indexer_url(), "https://indexer.example.com");
+        assert_eq!(config.protocol.gateway_url(), "https://gateway.example.com");
+    }
+
+    #[test]
+    fn loads_current_protocol_endpoints() {
+        let config: SidecarConfig = serde_json::from_str(
+            r#"{
+              "protocol": {
+                "chain_id": 480,
+                "registry_address": "0x8556d07D75025f286fe757C7EeEceC40D54FA16D",
+                "indexer": { "type": "direct", "url": "https://indexer.example.com" },
+                "gateway": { "type": "direct", "url": "https://gateway.example.com" },
+                "nullifier_oracle_urls": ["https://node0.example.com"],
+                "nullifier_oracle_threshold": 1
+              },
+              "identities": []
+            }"#,
+        )
+        .expect("current config should parse");
+
+        assert_eq!(config.protocol.indexer_url(), "https://indexer.example.com");
+        assert_eq!(config.protocol.gateway_url(), "https://gateway.example.com");
+    }
 }
 
 impl SidecarConfig {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -148,7 +148,11 @@ export function Modal() {
     setStatus(Status.Pending);
 
     const identityIndex = parseInt(activeIdentity.id, 10);
-    const isSession = !!bridgeInitialData.proof_request.session_id;
+    const proofType = bridgeInitialData.proof_request.proof_type;
+    const isSession =
+      proofType === "create_session" ||
+      proofType === "session" ||
+      (proofType == null && !!bridgeInitialData.proof_request.session_id);
     const endpoint = isSession ? "proof/session" : "proof/uniqueness";
 
     try {


### PR DESCRIPTION
This PR updates the simulator sidecar for the published World ID protocol 0.11 crates.

- Bumps the sidecar `world-id-*` dependencies to `0.11.0` from crates.io.
- Keeps proof generation on the 0.11 public API and preserves credential-unavailable handling.
- Adds compatibility for existing sidecar configs that still use `indexer_url` and `gateway_url`.
- Routes session proof requests by `proof_type`, with the old `session_id` fallback retained.

Validation:
- `cargo check --locked`
- `cargo test --locked`
- `pnpm lint`
- `pnpm typecheck`
