### PR TITLE
feat(sidecar): auto-select identity from requested credentials

### DIFF
--- a/sidecar/src/error.rs
+++ b/sidecar/src/error.rs
@@ -9,6 +9,11 @@ pub enum SidecarError {
     /// The user's credentials do not satisfy the proof request constraints.
     CredentialUnavailable,
     /// The requested identity index does not exist.
+    ///
+    /// No longer produced now that the proof endpoints auto-select the identity from the
+    /// requested credentials (the deprecated `identity_index` is ignored). Retained so the
+    /// `identity_not_found` error code / 404 mapping stays stable for any other caller.
+    #[allow(dead_code)]
     IdentityNotFound,
     /// The request body or proof_request itself is malformed.
     BadRequest(String),

--- a/sidecar/src/routes.rs
+++ b/sidecar/src/routes.rs
@@ -7,7 +7,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
-use world_id_core::requests::{ProofRequest, ProofResponse};
+use world_id_core::requests::{ProofRequest, ProofResponse, RequestItem};
 use world_id_core::{Authenticator, Credential, CredentialInput};
 
 use crate::auth::bearer_auth;
@@ -27,8 +27,11 @@ pub struct IdentityState {
 /// Request body for proof generation endpoints.
 #[derive(Debug, Deserialize)]
 pub struct ProofRequestBody {
-    /// Index into the pre-configured identities array.
-    pub identity_index: usize,
+    /// Deprecated and ignored: the identity is now auto-selected from the requested
+    /// credentials. Kept in the schema for backwards compatibility so existing callers
+    /// that still send it don't break.
+    #[serde(default)]
+    pub identity_index: Option<usize>,
     /// The ProofRequest from the bridge payload (passed through from IDKit).
     pub proof_request: serde_json::Value,
 }
@@ -99,16 +102,52 @@ async fn generate_session_proof(
     generate_proof_inner(&state, req, true).await
 }
 
+/// Available credential schema ids for a single identity.
+fn available_schema_ids(identity: &IdentityState) -> HashSet<u64> {
+    identity
+        .credentials
+        .iter()
+        .map(|c| c.issuer_schema_id)
+        .collect()
+}
+
+/// Selects the first identity (in config order) that can satisfy the proof request, returning
+/// its index and the request items to prove.
+///
+/// Pure and side-effect free — it only consults `ProofRequest::credentials_to_prove`, which
+/// checks schema-id availability and any constraint expression. It does NOT verify
+/// `expires_at_min` / `genesis_issued_at_min`; those are enforced later inside
+/// `generate_proof`, so a match here is necessary but not a full guarantee of success.
+///
+/// Takes the available schema ids lazily so production can stream them from `state.identities`
+/// without an intermediate allocation, while tests pass hand-built sets.
+fn select_identity(
+    available_per_identity: impl IntoIterator<Item = HashSet<u64>>,
+    proof_request: &ProofRequest,
+) -> Option<(usize, Vec<&RequestItem>)> {
+    available_per_identity
+        .into_iter()
+        .enumerate()
+        .find_map(|(index, available)| {
+            proof_request
+                .credentials_to_prove(&available)
+                .map(|items| (index, items))
+        })
+}
+
 /// Core proof generation logic shared between uniqueness and session proofs.
 async fn generate_proof_inner(
     state: &AppState,
     req: ProofRequestBody,
     is_session: bool,
 ) -> Result<Json<ProofResponse>, SidecarError> {
-    let identity = state
-        .identities
-        .get(req.identity_index)
-        .ok_or(SidecarError::IdentityNotFound)?;
+    // `identity_index` is deprecated: the identity is auto-selected from the requested
+    // credentials. Surface a migration signal when callers still send it.
+    if req.identity_index.is_some() {
+        tracing::warn!(
+            "identity_index is deprecated and ignored; identity is auto-selected from the requested credentials"
+        );
+    }
 
     let proof_request = ProofRequest::from_json(&req.proof_request.to_string())
         .map_err(|e| SidecarError::BadRequest(format!("invalid proof_request: {e}")))?;
@@ -119,16 +158,13 @@ async fn generate_proof_inner(
         ));
     }
 
-    // Check which credentials satisfy the request constraints
-    let available: HashSet<u64> = identity
-        .credentials
-        .iter()
-        .map(|c| c.issuer_schema_id)
-        .collect();
-
-    let items_to_prove = proof_request
-        .credentials_to_prove(&available)
+    // Auto-select: pick the first configured identity whose credentials satisfy the request.
+    let available = state.identities.iter().map(available_schema_ids);
+    let (selected_index, items_to_prove) = select_identity(available, &proof_request)
         .ok_or(SidecarError::CredentialUnavailable)?;
+
+    let identity = &state.identities[selected_index];
+    tracing::info!(selected_index, "auto-selected identity for proof request");
 
     let account_inclusion_proof = identity
         .authenticator
@@ -175,4 +211,111 @@ async fn generate_proof_inner(
         .map_err(SidecarError::from)?;
 
     Ok(Json(result.proof_response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Well-known schema ids (see idkit `CredentialType::issuer_schema_id`).
+    const POH: u64 = 1;
+    const PASSPORT: u64 = 9303;
+    const MNC: u64 = 9310;
+
+    /// Builds a valid uniqueness `ProofRequest` requesting the given (identifier, schema_id) items.
+    /// `proof_type` is omitted, which `world_id_core` treats as uniqueness.
+    fn proof_request(items: &[(&str, u64)]) -> ProofRequest {
+        let reqs: Vec<String> = items
+            .iter()
+            .map(|(id, schema)| {
+                format!(r#"{{"identifier":"{id}","issuer_schema_id":{schema}}}"#)
+            })
+            .collect();
+        let json = format!(
+            r#"{{
+              "id": "req_test",
+              "version": 1,
+              "created_at": 1725381192,
+              "expires_at": 1725381492,
+              "rp_id": "rp_0000000000000001",
+              "oprf_key_id": "0x1",
+              "session_id": null,
+              "action": "0x000000000000000000000000000000000000000000000000000000000000002a",
+              "signature": "0xa1fd06f0d8ceb541f6096fe2e865063eac1ff085c9d2bac2eedcc9ed03804bfc18d956b38c5ac3a8f7e71fde43deff3bda254d369c699f3c7a3f8e6b8477a5f51c",
+              "nonce": "0x0000000000000000000000000000000000000000000000000000000000000001",
+              "proof_requests": [{}]
+            }}"#,
+            reqs.join(",")
+        );
+        ProofRequest::from_json(&json).expect("valid test proof request")
+    }
+
+    /// Convenience: build the per-identity available-schema sets.
+    fn sets(per_identity: &[&[u64]]) -> Vec<HashSet<u64>> {
+        per_identity
+            .iter()
+            .map(|s| s.iter().copied().collect())
+            .collect()
+    }
+
+    /// Index of the selected identity, dropping the items (most assertions only care about which
+    /// identity was chosen).
+    fn selected_index(
+        available: &[HashSet<u64>],
+        request: &ProofRequest,
+    ) -> Option<usize> {
+        select_identity(available.iter().cloned(), request).map(|(index, _)| index)
+    }
+
+    #[test]
+    fn selects_identity_holding_requested_credential() {
+        // identity 0 = PoH + Passport, identity 1 = MNC.
+        let available = sets(&[&[POH, PASSPORT], &[MNC]]);
+
+        let poh = proof_request(&[("orb", POH)]);
+        assert_eq!(selected_index(&available, &poh), Some(0));
+
+        let passport = proof_request(&[("passport", PASSPORT)]);
+        assert_eq!(selected_index(&available, &passport), Some(0));
+
+        // MNC lives only on identity 1 — auto-selection must route there.
+        let mnc = proof_request(&[("mnc", MNC)]);
+        assert_eq!(selected_index(&available, &mnc), Some(1));
+    }
+
+    #[test]
+    fn returns_selected_items_to_prove() {
+        // The winning identity also yields the request items to prove (no recomputation needed).
+        let available = sets(&[&[POH, PASSPORT], &[MNC]]);
+        let mnc = proof_request(&[("mnc", MNC)]);
+        let (index, items) = select_identity(available.iter().cloned(), &mnc).expect("matches");
+        assert_eq!(index, 1);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].issuer_schema_id, MNC);
+    }
+
+    #[test]
+    fn returns_none_when_no_identity_has_the_credential() {
+        let available = sets(&[&[POH, PASSPORT], &[MNC]]);
+        // Schema 11 (selfie) is held by neither identity.
+        let selfie = proof_request(&[("selfie", 11)]);
+        assert_eq!(selected_index(&available, &selfie), None);
+    }
+
+    #[test]
+    fn first_match_wins_for_determinism() {
+        // Two identities both hold PoH; the first in config order is chosen.
+        let available = sets(&[&[POH], &[POH]]);
+        let poh = proof_request(&[("orb", POH)]);
+        assert_eq!(selected_index(&available, &poh), Some(0));
+    }
+
+    #[test]
+    fn credentials_split_across_identities_cannot_be_satisfied() {
+        // A single (no-constraint) request needing PoH AND MNC: neither identity has both,
+        // so no single identity satisfies it. Documents the one-proof-one-identity limit.
+        let available = sets(&[&[POH, PASSPORT], &[MNC]]);
+        let both = proof_request(&[("orb", POH), ("mnc", MNC)]);
+        assert_eq!(selected_index(&available, &both), None);
+    }
 }


### PR DESCRIPTION
## What & why

The sidecar's proof endpoints (`/proof/uniqueness`, `/proof/session`) selected the identity via a caller-supplied `identity_index`. That forces the web app to know which pre-configured identity holds which credential and to send the matching index — and it breaks down once credentials are **split across identities** (e.g. an MNC credential that must live on a separate identity from PoH/Passport, since one identity can't hold every credential).

This change makes the **sidecar pick the identity automatically** from the requested credentials, so the caller no longer has to.

## Changes (`sidecar/src/routes.rs`, `sidecar/src/error.rs`)

- **Auto-selection:** iterate the configured identities and use the first whose credentials satisfy the request, via a single `find_map` over `ProofRequest::credentials_to_prove` that returns both the index and the items to prove (no intermediate allocation, no recompute).
- **`identity_index` deprecated, not removed:** now `Option<usize>` with `#[serde(default)]`, so existing callers that still send it **don't break** — it's just ignored, and a `warn!` is logged when present.
- **Errors:** no match still returns `credential_unavailable` (400, unchanged). `IdentityNotFound` is no longer produced by these endpoints; the variant is retained (`#[allow(dead_code)]`) so its `identity_not_found`/404 mapping stays stable.
- **Tests:** unit tests for the pure selector — correct routing per credential, first-match determinism, no-match, and the one-proof-one-identity limitation (a single request needing credentials from two identities is unsatisfiable).

## Notes / limitations

- **One proof = one identity.** A single (no-constraint) request requiring schemas that live on different identities returns `credential_unavailable` — expected, documented in a test.
- **Cheap-match selection:** `credentials_to_prove` checks schema availability + constraint expressions but not `expires_at_min`/`genesis_issued_at_min` (those are enforced later in `generate_proof`), so a schema-matching-but-expired credential fails without falling back to another identity. This matches the intended behaviour.
- First match wins in config order; ordering matters when two identities share a schema.

## Testing

`cargo test` green (7 passed) on top of latest `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)